### PR TITLE
SHTK-8 : Implementing wait(), poll(), kill(), terminate() and send_signal().  SHTK-9 implementing user and group settings for shtk.Shell.

### DIFF
--- a/docs/build_shtk_rst.py
+++ b/docs/build_shtk_rst.py
@@ -30,5 +30,6 @@ for content_name in dir(shtk):
         print("\t:members:")
         print("\t:undoc-members:")
         print("\t:show-inheritance:")
+        print("\t:inherited-members:")
         print("")
 

--- a/docs/source/shtk.rst
+++ b/docs/source/shtk.rst
@@ -8,6 +8,7 @@ shtk.FileStream
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.FileStreamFactory
 ----------------------
@@ -16,6 +17,7 @@ shtk.FileStreamFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.Job
 --------
@@ -24,6 +26,7 @@ shtk.Job
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.ManualStream
 -----------------
@@ -32,6 +35,7 @@ shtk.ManualStream
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.ManualStreamFactory
 ------------------------
@@ -40,6 +44,7 @@ shtk.ManualStreamFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.NonzeroExitCodeException
 -----------------------------
@@ -48,6 +53,7 @@ shtk.NonzeroExitCodeException
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.NullStream
 ---------------
@@ -56,6 +62,7 @@ shtk.NullStream
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.NullStreamFactory
 ----------------------
@@ -64,6 +71,7 @@ shtk.NullStreamFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipeStream
 ---------------
@@ -72,6 +80,7 @@ shtk.PipeStream
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipeStreamFactory
 ----------------------
@@ -80,6 +89,7 @@ shtk.PipeStreamFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipelineChannel
 --------------------
@@ -88,6 +98,7 @@ shtk.PipelineChannel
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipelineChannelFactory
 ---------------------------
@@ -96,6 +107,7 @@ shtk.PipelineChannelFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipelineNode
 -----------------
@@ -104,6 +116,7 @@ shtk.PipelineNode
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipelineNodeFactory
 ------------------------
@@ -112,6 +125,7 @@ shtk.PipelineNodeFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipelineProcess
 --------------------
@@ -120,6 +134,7 @@ shtk.PipelineProcess
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.PipelineProcessFactory
 ---------------------------
@@ -128,6 +143,7 @@ shtk.PipelineProcessFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.Shell
 ----------
@@ -136,6 +152,7 @@ shtk.Shell
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.Stream
 -----------
@@ -144,6 +161,7 @@ shtk.Stream
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.StreamFactory
 ------------------
@@ -152,6 +170,7 @@ shtk.StreamFactory
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 
 shtk.util
 ---------
@@ -160,4 +179,5 @@ shtk.util
 	:members:
 	:undoc-members:
 	:show-inheritance:
+	:inherited-members:
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Custom test harness for shtk"""
 
+import os
 import unittest
 import coverage
 import pathlib
 
 def main():
-    testsdir = pathlib.Path('./shtk/test')
+    testsdir = pathlib.Path('./shtk/test').resolve()
     packagedir = testsdir.parent
 
-    covdir = pathlib.Path("./coverage")
+    covdir = pathlib.Path("./coverage").resolve()
     covdir.mkdir(exist_ok=True)
 
     covhtml = covdir / "html"
@@ -39,7 +40,7 @@ def main():
     runner.run(suite)
     cov.stop()
     cov.save()
-    cov.html_report(directory=str(covhtml.resolve()))
+    cov.html_report(directory=str(covhtml))
 
 main()
 

--- a/shtk/Job.py
+++ b/shtk/Job.py
@@ -58,6 +58,12 @@ class Job:
         event_loop (None or asyncio.AbstractEventLoop): The event loop to use
             for asyncio based processing.  If None is passed a new event loop
             is created from asyncio.new_event_loop() instead.
+        user (None, int, or str): The user that will be used to setreuid() any
+            child processes.  The behavior is the same as that of the user arg
+            to subprocess.Popen().
+        group (None, int, or str): The user that will be used to setregid() any
+            child processes.  The behavior is the same as that of the group arg
+            to subprocess.Popen().
 
     Attributes:
         cwd (str or Pathlib.Path): The current working directory in which to
@@ -71,6 +77,12 @@ class Job:
             PipelineFactory.build in run().
         pipeline_factory (PipelineNodeFactory): The command pipeline template
             that will be instantiated by the Job instance.
+        user (None, int, or str): The user that will be used to setreuid() any
+            child processes.  The behavior is the same as that of the user arg
+            to subprocess.Popen().
+        group (None, int, or str): The user that will be used to setregid() any
+            child processes.  The behavior is the same as that of the group arg
+            to subprocess.Popen().
 
 
     """
@@ -79,7 +91,9 @@ class Job:
         pipeline_factory,
         cwd = None,
         env = None,
-        event_loop = None
+        event_loop = None,
+        user = None,
+        group = None
     ):
         if env is None:
             self.environment = {}
@@ -88,6 +102,8 @@ class Job:
 
         self.pipeline_factory = pipeline_factory
         self.pipeline = None
+        self.user = user
+        self.group = group
 
         if event_loop is None:
             self.event_loop = asyncio.new_event_loop()
@@ -190,7 +206,7 @@ class Job:
             self,
             stdin_stream=stdin_stream,
             stdout_stream=stdout_stream,
-            stderr_stream=stderr_stream,
+            stderr_stream=stderr_stream
         )
 
         stdin_stream.close_reader()

--- a/shtk/PipelineNode.py
+++ b/shtk/PipelineNode.py
@@ -159,8 +159,8 @@ class PipelineProcess(PipelineNode):
             (including the base command).
         env (dict of str): The environment variables for the process
         stdin_stream (Stream): The Stream whose .reader() is used as stdin
-        stdout_stream (Stream): The Stream whose .reader() is used as stdout
-        stderr_stream (Stream): The Stream whose .reader() is used as stderr
+        stdout_stream (Stream): The Stream whose .writer() is used as stdout
+        stderr_stream (Stream): The Stream whose .writer() is used as stderr
 
     Raises:
         AssertionError: When len(args) <= 0

--- a/shtk/PipelineNode.py
+++ b/shtk/PipelineNode.py
@@ -5,6 +5,8 @@ Shells.
 
 import abc
 import asyncio
+import signal
+import sys
 
 from .util import export
 
@@ -50,42 +52,128 @@ class PipelineNode(abc.ABC):
         Runs the process
         """
 
-    @abc.abstractmethod
-    def poll(self):
+#    @abc.abstractmethod
+#    def poll(self):
+#        """
+#        Check if the child ProcessNodes have terminated.  Returns the exit code of
+#        processes that have completed, returns None for processes that have not
+#        completed.
+#
+#        Returns:
+#            list of (int or None):
+#                A list with one element per child process containing either an
+#                integer exit code for completed processes or None for
+#                incomplete processes.  
+#        """
+
+    @staticmethod
+    async def _get_return_code(rc_list, idx, coro):
+        rc_list[idx] = await coro
+
+    def _flatten_children(self):
+        ret = []
+        if len(self.children) > 0:
+            for child in self.children:
+                ret.extend(child._flatten_children())
+        else:
+            ret.append(self)
+
+        return ret
+
+    def send_signal(self, signal):
+        for child in self._flatten_children():
+            child.proc.send_signal(signal)
+
+    def terminate(self):
+        self.send_signal(signal.SIGTERM)
+
+    def kill(self):
+        self.send_signal(signal.SIGKILL)
+      
+    async def poll_async(self, ret):
         """
-        Check if the child processes have terminated.  Returns the exit code of
-        processes that have completed, returns None for processes that have not
-        completed.
+        Gets the return codes of all child ProcessNodes
+
+        Args:
+            ret (list of [int, None]): a list that will be modified to contain
+                a collection of return codes from flattened child ProcessNodes.
+                Child processes that have exited will be represented by their
+                return code.  Child processes that have not exited will be
+                represented by None.
+        """
+
+        ret.clear()
+
+        tasks = []
+        for it_child, child in enumerate(self._flatten_children()):
+            ret.append(None)
+            coro = self._get_return_code(ret, it_child, child.proc.wait())
+            task = self.event_loop.create_task(coro)
+            tasks.append(task)
+
+        try:
+            for task in tasks:
+                await task
+        except asyncio.CancelledError:
+            for task in tasks:
+                try:
+                    if not task.done():
+                        task.cancel()
+                        await task
+                except asyncio.CancelledError:
+                    pass
+        else:
+            return ret
+
+    def poll(self, timeout=1e-6):
+        """
+        Synchronous wrapper for poll_async().  Gets the return codes of all
+        child ProcessNodes.
 
         Returns:
-            list of (int or None):
-                A list with one element per child process containing either an
-                integer exit code for completed processes or None for
-                incomplete processes.  
+            list of (int or None): A list containing return codes from
+                flattened child ProcessNodes.  Child processes that have exited
+                will be represented by their integer return code.  Child
+                processes that have not exited will be represented by None.
         """
+
+        ret = []
+
+        try:
+            self.event_loop.run_until_complete(
+                asyncio.wait_for(
+                    self.poll_async(ret),
+                    timeout=timeout,
+                    loop=self.event_loop
+                )
+            )
+        except asyncio.TimeoutError:
+            pass
+            
+        return ret
       
-    @abc.abstractmethod
     async def wait_async(self):
         """
-        Waits for left and right PipelineNodes to complete
+        Waits for and retrieves the return codes of all child ProcessNodes.
 
         Returns:
             list of int:
-                Combined list of return codes from left (first) and right
-                (later) PipelineNode children.
+                A list of return codes from a flattened collection of child
+                processes.
         """
+
+        return await self.poll_async([])
       
     def wait(self):
         """
-        Synchronous wrapper for wait_async()
+        Synchronous wrapper for wait_async().
 
         Returns:
             list of int:
-                Combined list of return codes from left (first) and right
-                (later) PipelineNode children.
+                A list of return codes from a flattened collection of child
+                processes.
         """
-        task = self.wait_async()
-        return task.get_loop().run_until_complete(task)
+        return self.event_loop.run_until_complete(self.wait_async())
 
     @abc.abstractmethod
     def __repr__(self):
@@ -128,44 +216,44 @@ class PipelineChannel(PipelineNode):
     def __str__(self):
         return f"{self.left!s} | {self.right!s}"
 
-    def poll(self):
-        """
-        Check if the child processes have terminated.  Returns the exit code of
-        processes that have completed, returns None for processes that have not
-        completed.
-
-        Returns:
-            list of (int or None):
-                A list with one element per child process containing either an
-                integer exit code for completed processes or None for
-                incomplete processes.  
-        """
-
-        ret = []
-        ret.extend(self.left.poll())
-        ret.extend(self.right.poll())
-
-        return ret
-
-    async def wait_async(self):
-        """
-        Waits for left and right PipelineNodes to complete
-
-        Returns:
-            list of int:
-                Combined list of return codes from left (first) and right
-                (later) PipelineNode children.
-        """
-        ret = []
-        ret.extend(await self.left.wait_async())
-        ret.extend(await self.right.wait_async())
-        return ret
-
-    def wait(self):
-        ret = []
-        ret.extend(self.left.wait())
-        ret.extend(self.right.wait())
-        return ret
+#    def poll(self):
+#        """
+#        Check if the child ProcessNodes have terminated.  Returns the exit code of
+#        processes that have completed, returns None for processes that have not
+#        completed.
+#
+#        Returns:
+#            list of (int or None):
+#                A list with one element per child process containing either an
+#                integer exit code for completed processes or None for
+#                incomplete processes.  
+#        """
+#
+#        ret = []
+#        ret.extend(self.left.poll())
+#        ret.extend(self.right.poll())
+#
+#        return ret
+#
+#    async def wait_async(self):
+#        """
+#        Waits for left and right PipelineNodes to complete
+#
+#        Returns:
+#            list of int:
+#                Combined list of return codes from left (first) and right
+#                (later) PipelineNode children.
+#        """
+#        ret = []
+#        ret.extend(await self.left.wait_async())
+#        ret.extend(await self.right.wait_async())
+#        return ret
+#
+#    def wait(self):
+#        ret = []
+#        ret.extend(self.left.wait())
+#        ret.extend(self.right.wait())
+#        return ret
 
 @export
 class PipelineProcess(PipelineNode):
@@ -180,11 +268,15 @@ class PipelineProcess(PipelineNode):
         stdin_stream (Stream): The Stream whose .reader() is used as stdin
         stdout_stream (Stream): The Stream whose .writer() is used as stdout
         stderr_stream (Stream): The Stream whose .writer() is used as stderr
+        user (None, int, or str): The user to pass to
+            asyncio.create_subprocess_exec().  Requires Python >= 3.9.
+        group (None, int, or str): The group to pass to
+            asyncio.create_subprocess_exec().  Requires Python >= 3.9.
 
     Raises:
         AssertionError: When len(args) <= 0
     """
-    def __init__(self, event_loop, cwd, args, env, stdin_stream, stdout_stream, stderr_stream):
+    def __init__(self, event_loop, cwd, args, env, stdin_stream, stdout_stream, stderr_stream, user=None, group=None):
         super().__init__(event_loop)
 
         self.cwd = cwd
@@ -192,6 +284,8 @@ class PipelineProcess(PipelineNode):
         self.environment = dict(env)
         self.proc = None
         self.wait_future = None
+        self.user = user
+        self.group = group
 
         self.stdin_stream = stdin_stream
         self.stdout_stream = stdout_stream
@@ -203,6 +297,18 @@ class PipelineProcess(PipelineNode):
         """
         Runs the process using asyncio.create_subprocess_exec()
         """
+        
+        extra_kwargs = {}
+        if self.user is not None:
+            extra_kwargs['user'] = self.user
+            if (sys.version_info.major, sys.version_info.minor) < (3, 9):
+                raise NotImplementedError("Running subprocesses as a different user requires Python version >= 3.9")
+
+        if self.group is not None:
+            extra_kwargs['group'] = self.group
+            if (sys.version_info.major, sys.version_info.minor) < (3, 9):
+                raise NotImplementedError("Running subprocesses as a different group requires Python version >= 3.9")
+
         proc_start = asyncio.create_subprocess_exec(
             *self.args,
             stdin = self.stdin_stream.reader(),
@@ -212,81 +318,87 @@ class PipelineProcess(PipelineNode):
             env = self.environment,
             restore_signals = True,
             close_fds = True,
-            loop = self.event_loop
+            loop = self.event_loop,
+            **extra_kwargs
         )
         
-        print(proc_start)
-
         self.proc = await proc_start
 
-        self.wait_future = asyncio.shield(
-            self.event_loop.create_task(
-                self.proc.wait()
-            ),
-            loop=self.event_loop
-        )
+#        self.wait_future = self.event_loop.create_task(self.proc.wait())
 
-    def poll(self, timeout=1e-6):
-        """
-        Check if the child processes have terminated.  Returns the exit code of
-        processes that have completed, returns None for processes that have not
-        completed.
-
-        Raises:
-            RuntimeError: when called before self.run()
-
-        Returns:
-            list of (int or None):
-                A list with one element per child process containing either an
-                integer exit code for completed processes or None for
-                incomplete processes.  
-        """
-        if self.proc is None:
-            raise RuntimeError("Cannot poll a process that has not run yet.")
-        else:
-            if self.wait_future.done():
-                return [self.wait_future.result()]
-            else:
-                try:
-                    quick_wait = asyncio.wait_for(self.wait_future, timeout=timeout, loop=self.event_loop)
-                    return [self.event_loop.run_until_complete(quick_wait)]
-                except asyncio.TimeoutError:
-                    return [None]
-
-    def wait(self, timeout=None):
-        """
-        Blocks until the subprocess is completed and returns its returncode
-        within a one-element list.
-
-        Raises:
-            RuntimeError: when called before self.run()
-
-        Returns:
-            list of int:
-                A list of one integer
-        """
-
-        return self.poll(timeout=timeout)
+#    def poll(self, timeout=1e-6):
+#        """
+#        Check if the child ProcessNodes have terminated.  Returns the exit code
+#        of processes that have completed, returns None for processes that have
+#        not completed.  If the timeout expires before the return code is
+#        available then [None] is returned.
+#
+#        Args:
+#            timeout (float): number of seconds to wait
+#
+#        Raises:
+#            RuntimeError: when called before self.run()
+#
+#        Returns:
+#            list of (int or None):
+#                A list with one element per child process containing either an
+#                integer exit code for completed processes or None for
+#                incomplete processes.  
+#        """
+#        if self.proc is None:
+#            raise RuntimeError("Cannot poll a process that has not run yet.")
+#        else:
+#            if self.wait_future.done():
+#                return [self.wait_future.result()]
+#            else:
+#                try:
+#                    shielded_future = asyncio.shield(
+#                        self.wait_future,
+#                        loop=self.event_loop
+#                    )
+#                    quick_wait = asyncio.wait_for(shielded_future, timeout=timeout, loop=self.event_loop)
+#                    return [self.event_loop.run_until_complete(quick_wait)]
+#                except asyncio.TimeoutError:
+#                    return [None]
+#
+#    def wait(self, timeout=None):
+#        """
+#        Blocks until the subprocess is completed and returns its returncode
+#        within a one-element list.  If timeout expires before the return code
+#        is available code, then [None] is returned.  
+#
+#        Args:
+#            timeout (float): number of seconds to wait
+#
+#        Raises:
+#            RuntimeError: when called before self.run()
+#
+#        Returns:
+#            list of (int or None):
+#                A list of one integer
+#        """
+#
+#        return self.poll(timeout=timeout)
+#
+#    async def wait_async(self):
+#        """
+#        Blocks until the subprocess is completed and returns its returncode
+#        within a one-element list.
+#
+#        Raises:
+#            RuntimeError: when called before self.run()
+#
+#        Returns:
+#            list of int:
+#                A list of one integer
+#        """
+#        if self.proc is None:
+#            raise RuntimeError("Cannot wait on a process that has not run yet.")
+#        else:
+#            return [await self.wait_future]
 
     def __repr__(self):
         return f"PipelineProcess(cwd={self.cwd!r}, args={self.args!r}, env={self.environment!r}, stdin_stream={self.stdin_stream!r}, stdout_stream={self.stdout_stream!r}, stderr_stream={self.stderr_stream!r})" #pylint: disable=line-too-long
 
     def __str__(self):
         return f"PipelineProcess(args={self.args!r})"
-
-    async def wait_async(self):
-        """
-        Blocks until the subprocess is completed and returns its returncode
-        within a one-element list.
-
-        Raises:
-            RuntimeError: when called before self.run()
-
-        Returns:
-            list of int:
-                A list of one integer
-        """
-        if self.proc is None:
-            raise RuntimeError("Cannot wait on a process that has not run yet.")
-        else:
-            return [await self.wait_future]

--- a/shtk/PipelineNodeFactory.py
+++ b/shtk/PipelineNodeFactory.py
@@ -349,5 +349,7 @@ class PipelineProcessFactory(PipelineNodeFactory):
             args = self.args,
             stdin_stream = stdin_stream,
             stdout_stream = stdout_stream,
-            stderr_stream = stderr_stream
+            stderr_stream = stderr_stream,
+            user = job.user,
+            group = job.group
         )

--- a/shtk/PipelineNodeFactory.py
+++ b/shtk/PipelineNodeFactory.py
@@ -287,6 +287,7 @@ class PipelineChannelFactory(PipelineNodeFactory):
             ))
 
             return await PipelineChannel.create(
+                job.event_loop, 
                 left = await left_task,
                 right = await right_task
             )
@@ -342,6 +343,7 @@ class PipelineProcessFactory(PipelineNodeFactory):
         cwd = self.cwd or job.cwd
 
         return await PipelineProcess.create(
+            job.event_loop, 
             cwd = cwd,
             env = env,
             args = self.args,

--- a/shtk/Shell.py
+++ b/shtk/Shell.py
@@ -45,18 +45,29 @@ class Shell: # pylint: disable=too-many-arguments, too-many-instance-attributes
             sys.stderr)
         exceptions (boolean): Whether exceptions should be raised when non-zero
             exit codes are returned by subprocesses.
+        user (None, int, str): Run subprocesses as the given user.  If None,
+            run as same user as this process.  If int, run as user with
+            uid=user.  If str, run as user with name=user. Requires Python >=
+            3.9.
+        group (None, int, str): Run subprocesses as the given group.  If None,
+            run as same group as this process.  If int, run as group with
+            gid=group.  If str, run as group with name=group. Requires Python
+            >= 3.9.
     """
     _thread_vars = collections.defaultdict(dict)
 
     def __init__(
-        self, cwd=None, env=None, umask=None, stdin=None,
-        stdout=None, stderr=None, exceptions=True
+        self, cwd=None, env=None, umask=None, stdin=None, stdout=None,
+        stderr=None, exceptions=True, user=None, group=None
     ):
         self.lock = threading.RLock()
         self.exceptions = exceptions
         self.event_loop = None
 
         with self.lock:
+            self.user = user
+            self.group = group
+
             if env is None:
                 self.environment = dict(Shell.get_shell().environment)
             else:
@@ -101,8 +112,6 @@ class Shell: # pylint: disable=too-many-arguments, too-many-instance-attributes
                 If name is an str, then the name will be passed through
                 os.path.expanduser prior to lookup.
 
-            user: User to sudo to prior to execution (Default value = None)
-
         Returns:
             PipelineProcessFactory:
                 A PipelineProcessFactory node representing the command to be
@@ -135,10 +144,7 @@ class Shell: # pylint: disable=too-many-arguments, too-many-instance-attributes
         if not os.access(command_path, os.X_OK):
             raise RuntimeError(f"{command_path}: is not executable")
 
-        if user is None:
-            return PipelineProcessFactory(command_path)
-        else:
-            return PipelineProcessFactory('sudo', '-u', user, command_path)
+        return PipelineProcessFactory(command_path)
 
     def cd(self, path):
         """
@@ -311,7 +317,9 @@ class Shell: # pylint: disable=too-many-arguments, too-many-instance-attributes
                 pipeline_factory,
                 env=self.environment,
                 cwd=self.cwd,
-                event_loop=self.event_loop
+                event_loop=self.event_loop,
+                user=self.user,
+                group=self.group
             )
             self.event_loop.run_until_complete(
                 run_and_wait(job, exceptions=exceptions, wait=wait)

--- a/shtk/Shell.py
+++ b/shtk/Shell.py
@@ -363,7 +363,9 @@ class Shell: # pylint: disable=too-many-arguments, too-many-instance-attributes
             pipeline_factory.stdout(PipeStreamFactory()),
             env=self.environment,
             cwd=self.cwd,
-            event_loop=self.event_loop
+            event_loop=self.event_loop,
+            user=self.user,
+            group=self.group
         )
 
         job.run(

--- a/shtk/StreamFactory.py
+++ b/shtk/StreamFactory.py
@@ -97,9 +97,9 @@ class FileStreamFactory(StreamFactory):
         """
 
         if self.partial_path.is_absolute():
-            return FileStream(self.partial_path, self.mode)
+            return FileStream(self.partial_path, self.mode, user=job.user, group=job.group)
         else:
-            return FileStream(job.cwd / self.partial_path, self.mode)
+            return FileStream(job.cwd / self.partial_path, self.mode, user=job.user, group=job.group)
 
 @export
 class NullStreamFactory(StreamFactory):

--- a/shtk/test/PipelineNode/PipelineChannel.py
+++ b/shtk/test/PipelineNode/PipelineChannel.py
@@ -21,11 +21,13 @@ class TestCreateAndWait(TmpDirMixin):
         test_file = 'tmp.txt'
         cat = which('cat')
         message = "Hello World!"
+        event_loop = asyncio.new_event_loop()
 
         async def run_and_wait():
             with PipeStream(None) as p3, NullStream(None) as null_stream:
                 with PipeStream(None) as p1, PipeStream(None) as p2:
                     cat1 = await PipelineProcess.create(
+                        event_loop,
                         cwd = cwd.resolve(),
                         env = {},
                         args = [cat],
@@ -35,6 +37,7 @@ class TestCreateAndWait(TmpDirMixin):
                     )
 
                     cat2 = await PipelineProcess.create(
+                        event_loop,
                         cwd = cwd.resolve(),
                         env = {},
                         args = [cat],
@@ -44,8 +47,9 @@ class TestCreateAndWait(TmpDirMixin):
                     )
 
                     channel = await PipelineChannel.create(
-                        cat1,
-                        cat2
+                        event_loop,
+                        left = cat1,
+                        right = cat2
                     )
 
                     p1.writer().write(message)
@@ -58,7 +62,7 @@ class TestCreateAndWait(TmpDirMixin):
 
             return channel, returncodes, stdout_result
 
-        channel, returncodes, stdout_result = asyncio.run(run_and_wait())
+        channel, returncodes, stdout_result = event_loop.run_until_complete(run_and_wait())
 
         processes = [
             channel.left.proc,

--- a/shtk/test/PipelineNode/PipelineChannel.py
+++ b/shtk/test/PipelineNode/PipelineChannel.py
@@ -54,7 +54,7 @@ class TestCreateAndWait(TmpDirMixin):
 
                 stdout_result = p3.reader().read()
 
-                returncodes = await channel.wait()
+                returncodes = await channel.wait_async()
 
             return channel, returncodes, stdout_result
 

--- a/shtk/test/PipelineNode/PipelineProcess.py
+++ b/shtk/test/PipelineNode/PipelineProcess.py
@@ -40,7 +40,7 @@ class TestConstruct(TmpDirMixin):
 
 @export
 @register()
-class TestCreateAndWait(TmpDirMixin):
+class TestCreateAndWaitAsync(TmpDirMixin):
     def runTest(self):
         cwd = pathlib.Path(self.tmpdir.name)
         test_file = cwd / 'tmp.txt'
@@ -57,7 +57,7 @@ class TestCreateAndWait(TmpDirMixin):
                     stderr_stream = null_stream
                 )
 
-            await process.wait()
+            await process.wait_async()
 
             return process
 
@@ -94,7 +94,7 @@ class TestEnvironmentVariableExists(TmpDirMixin):
                     observed = stdout_stream.reader().read()
                     stdout_stream.close()
 
-                await process.wait()
+                await process.wait_async()
 
                 return process, observed
 

--- a/shtk/test/PipelineNodeFactory/PipelineChannelFactory.py
+++ b/shtk/test/PipelineNodeFactory/PipelineChannelFactory.py
@@ -7,6 +7,7 @@ import unittest
 from ...Stream import NullStream, FileStream
 from ...StreamFactory import NullStreamFactory, FileStreamFactory
 from ...PipelineNodeFactory import PipelineProcessFactory
+from ...Job import Job
 from ...util import which, export
 
 from ..test_util import register, TmpDirMixin
@@ -35,10 +36,11 @@ class TestBuildWithStdinStdout(TmpDirMixin):
         ppf2 = PipelineProcessFactory(which('cat'), cwd='./')
 
         ppf_channel = (ppf1 | ppf2).stdin(input_file.resolve()).stdout(output_file.resolve()).stderr(null_stream)
+        job = Job(ppf_channel, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf_channel,
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [0, 0])

--- a/shtk/test/PipelineNodeFactory/PipelineChannelFactory.py
+++ b/shtk/test/PipelineNodeFactory/PipelineChannelFactory.py
@@ -15,7 +15,7 @@ __all__ = []
 
 async def build_and_wait(factory, *args, **kwargs):
     obj = await factory.build(*args, **kwargs)
-    return await obj.wait()
+    return await obj.wait_async()
 
 @export
 @register()

--- a/shtk/test/PipelineNodeFactory/PipelineProcessFactory.py
+++ b/shtk/test/PipelineNodeFactory/PipelineProcessFactory.py
@@ -8,6 +8,7 @@ from ...Stream import NullStream, FileStream
 from ...StreamFactory import NullStreamFactory, FileStreamFactory
 from ...PipelineNodeFactory import PipelineProcessFactory
 from ...util import which, export
+from ...Job import Job
 
 from ..test_util import register, TmpDirMixin
 
@@ -57,10 +58,11 @@ class TestBuildWithExplicitStreamsStdinStdout(TmpDirMixin):
         null_stream = NullStream()
 
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf,
-            None,
+            job,
             stdin_stream=stdin_stream,
             stdout_stream=stdout_stream,
             stderr_stream=null_stream
@@ -119,10 +121,11 @@ class TestBuildWithStreamFactoryStdinStdout(TmpDirMixin):
         null_stream = None
 
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf.stdin(stdin_stream).stdout(stdout_stream).stderr(null_stream),
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [0])
@@ -145,10 +148,11 @@ class TestBuildWithStreamFactoryStderr(TmpDirMixin):
         null_stream = None
 
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf.stdin(null_stream).stdout(null_stream).stderr(stderr_stream),
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [1])
@@ -175,10 +179,11 @@ class TestBuildWithFilePathStdinStdout(TmpDirMixin):
         null = None
 
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf.stdin(stdin).stdout(stdout).stderr(null),
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [0])
@@ -201,10 +206,11 @@ class TestBuildWithFilePathStderr(TmpDirMixin):
         null = None
 
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf.stdin(null).stdout(null).stderr(stderr),
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [1])
@@ -231,10 +237,11 @@ class TestBuildWithPathlibStdinStdout(TmpDirMixin):
         null = None
 
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf.stdin(stdin).stdout(stdout).stderr(null),
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [0])
@@ -257,10 +264,11 @@ class TestBuildWithPathlibStderr(TmpDirMixin):
         null = None
 
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
+        job = Job(ppf, cwd=cwd)
 
         return_codes = asyncio.run(build_and_wait(
             ppf.stdin(null).stdout(null).stderr(stderr),
-            None
+            job
         ))
 
         self.assertEqual(return_codes, [1])

--- a/shtk/test/PipelineNodeFactory/PipelineProcessFactory.py
+++ b/shtk/test/PipelineNodeFactory/PipelineProcessFactory.py
@@ -15,7 +15,7 @@ __all__ = []
 
 async def build_and_wait(factory, *args, **kwargs):
     obj = await factory.build(*args, **kwargs)
-    return await obj.wait()
+    return await obj.wait_async()
 
 @export
 @register()

--- a/shtk/test/PipelineNodeFactory/PipelineProcessFactory.py
+++ b/shtk/test/PipelineNodeFactory/PipelineProcessFactory.py
@@ -29,10 +29,11 @@ class TestBuild(TmpDirMixin):
 
         ppf = PipelineProcessFactory(which('touch'), cwd='./')
         ppf = ppf(tmp_file.resolve())
+        job = Job(None, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf,
-            None,
+            job,
             stdin_stream=null_stream,
             stdout_stream=null_stream,
             stderr_stream=null_stream
@@ -58,9 +59,9 @@ class TestBuildWithExplicitStreamsStdinStdout(TmpDirMixin):
         null_stream = NullStream()
 
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
-        job = Job(ppf, cwd=cwd)
+        job = Job(None, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf,
             job,
             stdin_stream=stdin_stream,
@@ -88,10 +89,11 @@ class TestBuildWithExplicitStreamsStderr(TmpDirMixin):
         null_stream = NullStream()
 
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
+        job = Job(None, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf,
-            None,
+            job,
             stdin_stream=null_stream,
             stdout_stream=null_stream,
             stderr_stream=stderr_stream
@@ -123,7 +125,7 @@ class TestBuildWithStreamFactoryStdinStdout(TmpDirMixin):
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
         job = Job(ppf, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf.stdin(stdin_stream).stdout(stdout_stream).stderr(null_stream),
             job
         ))
@@ -150,7 +152,7 @@ class TestBuildWithStreamFactoryStderr(TmpDirMixin):
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
         job = Job(ppf, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf.stdin(null_stream).stdout(null_stream).stderr(stderr_stream),
             job
         ))
@@ -181,7 +183,7 @@ class TestBuildWithFilePathStdinStdout(TmpDirMixin):
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
         job = Job(ppf, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf.stdin(stdin).stdout(stdout).stderr(null),
             job
         ))
@@ -208,7 +210,7 @@ class TestBuildWithFilePathStderr(TmpDirMixin):
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
         job = Job(ppf, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf.stdin(null).stdout(null).stderr(stderr),
             job
         ))
@@ -239,7 +241,7 @@ class TestBuildWithPathlibStdinStdout(TmpDirMixin):
         ppf = PipelineProcessFactory(which('cat'), cwd='./')
         job = Job(ppf, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf.stdin(stdin).stdout(stdout).stderr(null),
             job
         ))
@@ -266,7 +268,7 @@ class TestBuildWithPathlibStderr(TmpDirMixin):
         ppf = PipelineProcessFactory(which('cat'), input_file.resolve(), cwd='./')
         job = Job(ppf, cwd=cwd)
 
-        return_codes = asyncio.run(build_and_wait(
+        return_codes = job.event_loop.run_until_complete(build_and_wait(
             ppf.stdin(null).stdout(null).stderr(stderr),
             job
         ))

--- a/shtk/test/Shell/Shell.py
+++ b/shtk/test/Shell/Shell.py
@@ -126,7 +126,7 @@ class TestWithEnvironment(TmpDirMixin):
         message = 'Hello World!'
         MESSAGE = 'MESSAGE'
         os.environ[MESSAGE] = message
-        with Shell(env=os.environ) as sh:
+        with Shell(env=os.environ, cwd=os.getcwd()) as sh:
             self.assertEqual(message, sh.getenv(MESSAGE))
             self.assertEqual(num_existing + 1, len(sh.environment))
 
@@ -140,7 +140,7 @@ class TestChangeDirectory(TmpDirMixin):
 
         message = "Hello World!"
 
-        with Shell() as sh:
+        with Shell(cwd=cwd) as sh:
             cat = sh.command('cat')
 
             with (cwd / input_file).open('w') as fout:
@@ -170,7 +170,7 @@ class TestEvaluate(TmpDirMixin):
 
         message = "Hello World!"
 
-        with Shell() as sh:
+        with Shell(cwd=cwd) as sh:
             cat = sh.command('cat')
 
             with (cwd / input_file).open('w') as fout:
@@ -191,7 +191,7 @@ class TestEnvironmentSet(TmpDirMixin):
 
         from .. import test_util
         with importlib.resources.path(test_util.__package__, 'echo_env.py') as echo_env:
-            with Shell() as sh:
+            with Shell(cwd=cwd) as sh:
                 sh.export(
                     MESSAGE = message
                 )
@@ -213,7 +213,7 @@ class TestEnvironmentSetGet(TmpDirMixin):
 
         from .. import test_util
 
-        with Shell() as sh:
+        with Shell(cwd=cwd) as sh:
             sh.export(
                 MESSAGE = message
             )
@@ -234,7 +234,7 @@ class TestChangeDirectoryManager(TmpDirMixin):
 
         os.chdir("/")
 
-        with Shell() as sh:
+        with Shell(cwd=os.getcwd()) as sh:
             cat = sh.command(which('cat'))
 
             with input_file.open('w') as fout:

--- a/shtk/test/Shell/Shell.py
+++ b/shtk/test/Shell/Shell.py
@@ -100,12 +100,15 @@ class TestCommandNotExecutable(TmpDirMixin):
 class TestCommandNotReadable(TmpDirMixin):
     def runTest(self):
         cwd = pathlib.Path(self.tmpdir.name)
-        tmpfile = cwd / "notreadable"
+        tmpfile = cwd / "notreadable.sh"
 
         tmpfile.touch(mode=0o300)
 
         with Shell(cwd=cwd) as sh:
-            with self.assertRaises(RuntimeError):
+            if os.getuid() != 0:
+                with self.assertRaises(RuntimeError):
+                    sh.command(f"./{tmpfile.name}")
+            else:
                 sh.command(f"./{tmpfile.name}")
 
 @export

--- a/shtk/test/StreamFactory/FileStreamFactory.py
+++ b/shtk/test/StreamFactory/FileStreamFactory.py
@@ -1,6 +1,7 @@
 import unittest
 import pathlib
 
+from ...Job import Job
 from ...StreamFactory import FileStreamFactory
 from ...util import export
 
@@ -16,10 +17,12 @@ class TestRead(TmpDirMixin):
         tmpfile = (cwd / "tmp.txt").resolve()
         message = "Hello World!"
 
+        job = Job(None, cwd=cwd)
+
         with open(tmpfile, 'w') as fout:
             fout.write(message)
 
-        with FileStreamFactory(tmpfile, mode='r').build(None) as fs:
+        with FileStreamFactory(tmpfile, mode='r').build(job) as fs:
             observed = fs.reader().read()
         
         self.assertEqual(message, observed)
@@ -32,7 +35,9 @@ class TestWrite(TmpDirMixin):
         tmpfile = (cwd / "tmp.txt").resolve()
         message = "Hello World!"
 
-        with FileStreamFactory(tmpfile, mode='w').build(None) as fs:
+        job = Job(None, cwd=cwd)
+
+        with FileStreamFactory(tmpfile, mode='w').build(job) as fs:
             fs.writer().write(message)
 
         with open(tmpfile, 'r') as fin:
@@ -48,10 +53,12 @@ class TestAppend(TmpDirMixin):
         tmpfile = (cwd / "tmp.txt").resolve()
         message = "Hello World!"
 
+        job = Job(None, cwd=cwd)
+
         with open(tmpfile, 'w') as fout:
             fout.write(message)
 
-        with FileStreamFactory(tmpfile, mode='a').build(None) as fs:
+        with FileStreamFactory(tmpfile, mode='a').build(job) as fs:
             fs.writer().write(message)
 
         with open(tmpfile, 'r') as fin:

--- a/shtk/test/test_util.py
+++ b/shtk/test/test_util.py
@@ -30,12 +30,13 @@ class TmpDirMixin(unittest.TestCase):
     def setUp(self):
         """Create the temporary directory"""
         super().setUp()
+        self.old_cwd = os.getcwd()
         self.tmpdir = tempfile.TemporaryDirectory()
-        self.prevcwd = os.getcwd()
-        os.chdir(self.tmpdir.name)
+        os.chdir(self.tmpdir.__enter__())
 
     def tearDown(self):
         """Delete the temporary directory"""
-        os.chdir(self.prevcwd)
+        os.chdir(self.old_cwd)
+        self.tmpdir.__exit__(None, None, None)
         self.tmpdir.cleanup()
         super().tearDown()


### PR DESCRIPTION
In the interest of moving towards feature parity with subprocess.Popen I've added several new features to shtk.Shell.  First, shtk.ProcessNode instances now implement the following helper functions:
* wait() and wait_async()
* poll() and poll_async()
* send_signal()
* terminate()
* kill()

Also in this update I've decided to implement SHTK-9, which implements user and group selection for subprocesses executed by shtk.Shell().  This eliminates some common cases where a call to "sudo" or "su" would be necessary.