### PR TITLE
SHTK-0022 : Fixing more stream issues.

### DIFF
--- a/shtk/Job.py
+++ b/shtk/Job.py
@@ -188,6 +188,15 @@ class Job:
         stdout_stream.close()
         stderr_stream.close()
 
+        if self.pipeline.stdin_stream is not None:
+            self.pipeline.stdin_stream.close()
+
+        if self.pipeline.stdout_stream is not None:
+            self.pipeline.stdout_stream.close()
+
+        if self.pipeline.stderr_stream is not None:
+            self.pipeline.stderr_stream.close()
+
     def run(self, stdin_factory, stdout_factory, stderr_factory):
         """
         Creates and runs a new pipeline

--- a/shtk/PipelineNode.py
+++ b/shtk/PipelineNode.py
@@ -52,6 +52,10 @@ class PipelineNode(abc.ABC):
         Runs the process
         """
 
+        self.stdin_stream.close_reader()
+        self.stdout_stream.close_writer()
+        self.stderr_stream.close_writer()
+
     @staticmethod
     async def _get_return_code(rc_list, idx, coro):
         rc_list[idx] = await coro
@@ -302,6 +306,8 @@ class PipelineProcess(PipelineNode):
         )
 
         self.proc = await proc_start
+
+        await super().run()
 
     def __repr__(self):
         return f"PipelineProcess(cwd={self.cwd!r}, args={self.args!r}, env={self.environment!r}, stdin_stream={self.stdin_stream!r}, stdout_stream={self.stdout_stream!r}, stderr_stream={self.stderr_stream!r})" #pylint: disable=line-too-long


### PR DESCRIPTION
There were still issues with how PipelineNode's were handling their streams.  This change closes streams stdin.reader(), stdout.writer(), and stderr.writer() streams managed by SHTK whenever the PipelineNode instance starts running.  